### PR TITLE
docs: add Performance note (File::seek/lseek)

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,3 +10,8 @@ Example:
 ```
 cargo run -- README.md
 ```
+
+## Performance
+- Jumps directly to the last byte using `std::fs::File::seek`.
+- On Unix, this maps to the `lseek(2)` system call, so it does not read the whole file.
+- O(1) with respect to file size; writes a single byte only when needed.


### PR DESCRIPTION
- Describe using File::seek (Unix: lseek) to jump to EOF
- O(1) regardless of file size; writes only when needed
- Keep a single, simple usage example in a fenced code block